### PR TITLE
Port to Eloquent, fixes #43

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ The driver communicates with the drone using the Tello SDK, which has several ad
 arbitrary strings to the drone.
 
 Many Tello commands (e.g., `takeoff` and `land`) are long-running, and the drone returns `ok` or `error` on completion.
-For now, the driver provides the ROS service `tello_command` to initiate commands,
+The driver provides the ROS service `tello_command` to initiate commands,
 and the corresponding ROS topic `tello_response` to indicate command completion.
-This may change when ROS2-Dashing is released.
 
 Per ROS convention, the driver also responds to `Twist` messages on the `cmd_vel` topic.
 These are translated into `rc` commands and sent to the drone.
@@ -94,7 +93,7 @@ sudo apt install libasio-dev
 
 ### 2. Set up your ROS environment
 
-[Install ROS2 Dashing Diademata](https://index.ros.org/doc/ros2/Installation/) with the `ros-dashing-desktop` option.
+[Install ROS2 Eloquent Elusor](https://index.ros.org/doc/ros2/Installation/) with the `ros-eloquent-desktop` option.
 
 If you install binaries, be sure to also install the 
 [development tools and ROS tools](https://github.com/ros2/ros2/wiki/Linux-Development-Setup#install-development-tools-and-ros-tools)
@@ -102,7 +101,7 @@ from the source installation instructions.
 
 Install these additional packages:
 ~~~
-sudo apt install ros-dashing-cv-bridge ros-dashing-camera-calibration-parsers
+sudo apt install ros-eloquent-cv-bridge ros-eloquent-camera-calibration-parsers
 ~~~
 
 ### 3. Install `tello_ros`
@@ -114,7 +113,7 @@ cd ~/tello_ros_ws/src
 git clone https://github.com/clydemcqueen/tello_ros.git
 git clone https://github.com/ptrmu/ros2_shared.git
 cd ..
-source /opt/ros/dashing/setup.bash
+source /opt/ros/eloquent/setup.bash
 # If you didn't intall Gazebo, skip tello_gazebo while building:
 colcon build --event-handlers console_direct+ --packages-skip tello_gazebo
 ~~~

--- a/README.md
+++ b/README.md
@@ -118,9 +118,7 @@ source /opt/ros/eloquent/setup.bash
 colcon build --event-handlers console_direct+ --packages-skip tello_gazebo
 ~~~
 
-## Running
-
-### Teleop
+## Teleop
 
 The driver provides a simple launch file that will allow you to fly the drone using a wired XBox One gamepad.
 
@@ -147,12 +145,40 @@ ros2 topic pub /cmd_vel geometry_msgs/Twist  # Sends rc 0 0 0 0
 ros2 topic pub /cmd_vel geometry_msgs/Twist "{linear: {x: 0.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 0.2}}"
 ~~~~
 
-### Devices tested
+## Devices tested
 
 * Tello
   * Firmware v01.04.35.01, SDK v1.3
 * Tello EDU
   * Firmware v02.04.69.03, SDK v2.0
+
+## Versions and branches
+
+`tello_ros` was developed along with several other projects while ROS2 was rapidly changing.
+All of the related projects adopted similar conventions around branch names:
+* the `master` branch works with the latest ROS2 release (Eloquent as of this writing)
+* there may be branches for older ROS2 versions, such as `crystal` or `dashing`
+
+The following projects and branches were tested together:
+
+* ROS Dashing:
+  * git clone https://github.com/ptrmu/ros2_shared.git
+  * git clone https://github.com/ptrmu/fiducial_vlam.git
+  * git clone https://github.com/clydemcqueen/tello_ros.git -b dashing
+  * git clone https://github.com/clydemcqueen/flock2.git -b dashing
+
+* ROS2 Eloquent with fiducial_vlam:
+  * git clone https://github.com/ptrmu/ros2_shared.git
+  * git clone https://github.com/ptrmu/fiducial_vlam.git
+  * git clone https://github.com/clydemcqueen/tello_ros.git
+  * git clone https://github.com/clydemcqueen/flock2.git
+
+* ROS2 Eloquent with fiducial_vlam_sam:
+  * git clone https://github.com/ptrmu/ros2_shared.git
+  * git clone https://github.com/ptrmu/fiducial_vlam_sam.git
+  * git clone https://github.com/clydemcqueen/sim_fiducial.git
+  * git clone https://github.com/clydemcqueen/tello_ros.git
+  * git clone https://github.com/clydemcqueen/flock2.git
 
 ## Credits
 

--- a/tello_description/src/replace.py
+++ b/tello_description/src/replace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Replace strings like ${key} with a value

--- a/tello_driver/launch/emulators_launch.py
+++ b/tello_driver/launch/emulators_launch.py
@@ -1,6 +1,6 @@
 from launch import LaunchDescription
-from launch_ros.actions import Node
 from launch.actions import ExecuteProcess
+from launch_ros.actions import Node
 
 
 # Launch two emulators and two drivers for testing
@@ -10,17 +10,17 @@ def generate_launch_description():
     emulator_path = 'install/tello_driver/lib/tello_driver/tello_emulator'
     localhost = '127.0.0.1'
 
-    dr1_cmd_port = '11001'
-    dr2_cmd_port = '11002'
+    dr1_cmd_port = 11001
+    dr2_cmd_port = 11002
 
-    em1_port = '12001'
-    em2_port = '12002'
+    em1_port = 12001
+    em2_port = 12002
 
-    dr1_data_port = '13001'
-    dr2_data_port = '13002'
+    dr1_data_port = 13001
+    dr2_data_port = 13002
 
-    dr1_video_port = '14001'
-    dr2_video_port = '14002'
+    dr1_video_port = 14001
+    dr2_video_port = 14002
 
     dr1_params = [{
         'drone_ip': localhost,
@@ -39,8 +39,10 @@ def generate_launch_description():
     }]
 
     return LaunchDescription([
-        ExecuteProcess(cmd=[emulator_path, 'em1', em1_port, dr1_data_port, dr1_video_port], output='screen'),
-        ExecuteProcess(cmd=[emulator_path, 'em2', em2_port, dr2_data_port, dr2_video_port], output='screen'),
+        ExecuteProcess(cmd=[emulator_path, 'em1', str(em1_port), str(dr1_data_port), str(dr1_video_port)],
+                       output='screen'),
+        ExecuteProcess(cmd=[emulator_path, 'em2', str(em2_port), str(dr2_data_port), str(dr2_video_port)],
+                       output='screen'),
         Node(package='tello_driver', node_executable='tello_driver_main', node_name='dr1', node_namespace='dr1',
              parameters=dr1_params, output='screen'),
         Node(package='tello_driver', node_executable='tello_driver_main', node_name='dr2', node_namespace='dr2',

--- a/tello_driver/src/tello_driver_node.cpp
+++ b/tello_driver/src/tello_driver_node.cpp
@@ -57,7 +57,7 @@ namespace tello_driver
 
     // ROS subscription
     cmd_vel_sub_ = create_subscription<geometry_msgs::msg::Twist>(
-      "cmd_vel", std::bind(&TelloDriverNode::cmd_vel_callback, this, std::placeholders::_1));
+      "cmd_vel", 1, std::bind(&TelloDriverNode::cmd_vel_callback, this, std::placeholders::_1));
 
     // ROS timer
     using namespace std::chrono_literals;

--- a/tello_driver/src/tello_joy_node.cpp
+++ b/tello_driver/src/tello_joy_node.cpp
@@ -13,7 +13,7 @@ namespace tello_joy
   {
     using std::placeholders::_1;
 
-    joy_sub_ = create_subscription<sensor_msgs::msg::Joy>("joy", std::bind(&TelloJoyNode::joy_callback, this, _1));
+    joy_sub_ = create_subscription<sensor_msgs::msg::Joy>("joy", 1, std::bind(&TelloJoyNode::joy_callback, this, _1));
     cmd_vel_pub_ = create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 1);
     tello_client_ = create_client<tello_msgs::srv::TelloAction>("tello_action");
 

--- a/tello_driver/src/video_socket.cpp
+++ b/tello_driver/src/video_socket.cpp
@@ -101,8 +101,10 @@ namespace tello_driver
             std_msgs::msg::Header header{};
             header.frame_id = "camera_frame";
             header.stamp = stamp;
-            cv_bridge::CvImage image{header, sensor_msgs::image_encodings::BGR8, mat};
-            driver_->image_pub_->publish(image.toImageMsg());
+            cv_bridge::CvImage cv_image{header, sensor_msgs::image_encodings::BGR8, mat};
+            sensor_msgs::msg::Image sensor_image_msg;
+            cv_image.toImageMsg(sensor_image_msg);
+            driver_->image_pub_->publish(sensor_image_msg);
           }
 
           if (driver_->count_subscribers(driver_->camera_info_pub_->get_topic_name()) > 0) {

--- a/tello_gazebo/README.md
+++ b/tello_gazebo/README.md
@@ -7,7 +7,7 @@
 * `inject_entity.py` is a script that will read an URDF (ROS) or SDF (Gazebo) file and spawn a model in a running instance of Gazebo
 * the built-in camera plugin is used to emulate the Gazebo forward-facing camera
 
-As of this writing ROS2 Dashing + Gazebo v9 integration is still developing. YMMV.
+As of this writing ROS2 Eloquent + Gazebo v9 integration is still developing. YMMV.
 
 #### Python
 
@@ -21,7 +21,7 @@ Run `gazebo` on the command line, fix any problems before continuing.
 
 #### Additional ROS packages
 
-    sudo apt install ros-dashing-gazebo-ros-pkgs ros-dashing-cv-bridge
+    sudo apt install ros-eloquent-gazebo-ros-pkgs ros-eloquent-cv-bridge
 
 #### Run a teleop simulation
 

--- a/tello_gazebo/launch/simple_launch.py
+++ b/tello_gazebo/launch/simple_launch.py
@@ -36,6 +36,6 @@ def generate_launch_description():
              node_namespace=ns),
 
         # Joystick controller, generates /namespace/cmd_vel messages
-        Node(package='tello_driver', node_executable='tello_joy', output='screen',
+        Node(package='tello_driver', node_executable='tello_joy_main', output='screen',
              node_namespace=ns),
     ])

--- a/tello_gazebo/launch/vlam_launch.py
+++ b/tello_gazebo/launch/vlam_launch.py
@@ -44,7 +44,7 @@ def generate_launch_description():
              node_namespace=drones[0]),
 
         # Joystick controller, generates /namespace/cmd_vel messages
-        Node(package='tello_driver', node_executable='tello_joy', output='screen',
+        Node(package='tello_driver', node_executable='tello_joy_main', output='screen',
              node_namespace=drones[0]),
     ]
 

--- a/tello_gazebo/src/inject_entity.py
+++ b/tello_gazebo/src/inject_entity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Inject an SDF or URDF file into Gazebo"""
 

--- a/tello_gazebo/src/tello_plugin.cpp
+++ b/tello_gazebo/src/tello_plugin.cpp
@@ -194,7 +194,7 @@ namespace tello_gazebo
 
       std::string link_name{"base_link"};
 
-      // In theory we can move much of this config into the <ros> tag, but this appears unfinished in Dashing?
+      // In theory we can move much of this config into the <ros> tag, perhaps it's finished in Eloquent?
       if (sdf->HasElement("link_name")) {
         link_name = sdf->GetElement("link_name")->Get<std::string>();
       }

--- a/tello_msgs/CMakeLists.txt
+++ b/tello_msgs/CMakeLists.txt
@@ -10,8 +10,8 @@ endif ()
 if ($ENV{CLION_IDE})
   message("Running inside CLion")
   find_package(fastrtps_cmake_module REQUIRED)
-  set(FastRTPS_INCLUDE_DIR "/opt/ros/dashing/include")
-  set(FastRTPS_LIBRARY_RELEASE "/opt/ros/dashing/lib/libfastrtps.so")
+  set(FastRTPS_INCLUDE_DIR "/opt/ros/eloquent/include")
+  set(FastRTPS_LIBRARY_RELEASE "/opt/ros/eloquent/lib/libfastrtps.so")
 endif ()
 
 # Debugging: set _dump_all_variables to true


### PR DESCRIPTION
Fairly small changes.

Biggest change was the conversion of CvImage to sensor_msgs::msg::Image -- the API I was using expects a unique_ptr, not a shared_ptr. I found a different method.

I ran through all of the launch files (except tello_gazebo/vlam_launch.py), flew a drone, and ran the simulation -- everything appears to work.